### PR TITLE
fix case sensitive import

### DIFF
--- a/src/visualize/index.coffee
+++ b/src/visualize/index.coffee
@@ -1,4 +1,4 @@
-Graph = require('../Graph').Graph
+Graph = require('../graph').Graph
 
 exports.serialize = serialize = require './serialize'
 exports.markup    = markup    = require './markup'


### PR DESCRIPTION
This fixes the build on case sensitive file systems (like ext4 on linux) by adapting the import `../Graph` to the folder `src/graph`.
