### PR TITLE
Fix path

### DIFF
--- a/src/visualize/index.coffee
+++ b/src/visualize/index.coffee
@@ -1,4 +1,4 @@
-Graph = require('../Graph').Graph
+Graph = require('../graph').Graph
 
 exports.serialize = serialize = require './serialize'
 exports.markup    = markup    = require './markup'


### PR DESCRIPTION
Under Windows this is not a problem (because filenames are case-insensitive) but under Linux that single character prevented shadergraph from building.